### PR TITLE
Add "Accept: application/dns-message" as for RFC 8484 Guidance

### DIFF
--- a/src/dns_client/client_https.c
+++ b/src/dns_client/client_https.c
@@ -44,6 +44,7 @@ int _dns_client_send_https(struct dns_server_info *server_info, void *packet, un
 						"Host: %s\r\n"
 						"User-Agent: smartdns\r\n"
 						"Content-Type: application/dns-message\r\n"
+						"Accept: application/dns-message\r\n"
 						"Content-Length: %d\r\n"
 						"\r\n",
 						https_flag->path, https_flag->httphost, len);


### PR DESCRIPTION
The DoH client SHOULD include an HTTP Accept request header field to indicate what type of content can be understood in response. Irrespective of the value of the Accept request header field, the client MUST be prepared to process "application/dns-message" (as described in Section 6) responses but MAY also process other DNS-related media types it receives.